### PR TITLE
fix: Add MySqlPlatform for DBAL version <= 3.2

### DIFF
--- a/src/Upsert.php
+++ b/src/Upsert.php
@@ -8,6 +8,7 @@ use BackedEnum;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
+use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use RuntimeException;
@@ -121,22 +122,24 @@ final class Upsert
 
         return match (true) {
             $platform instanceof PostgreSQLPlatform => <<<POSTGRESQL
-INSERT INTO "{$this->table}" ({$columns})
-VALUES ({$values})
-ON CONFLICT ({$identifiers}) DO UPDATE SET {$updates}
-POSTGRESQL
+                INSERT INTO "{$this->table}" ({$columns})
+                VALUES ({$values})
+                ON CONFLICT ({$identifiers}) DO UPDATE SET {$updates}
+                POSTGRESQL
         ,
-            $platform instanceof AbstractMySQLPlatform => <<<MYSQL
-INSERT INTO {$this->table} ({$columns})
-VALUES ({$values})
-ON DUPLICATE KEY UPDATE {$updates}
-MYSQL
-        ,$platform instanceof SqlitePlatform => <<<SQLITE
-INSERT INTO {$this->table} ({$columns})
-VALUES ({$values})
-ON CONFLICT({$identifiers}) DO UPDATE SET {$updates}
-SQLITE
-            ,default => throw new RuntimeException(
+            $platform instanceof AbstractMySQLPlatform || $platform instanceof MySqlPlatform => <<<MYSQL
+                INSERT INTO {$this->table} ({$columns})
+                VALUES ({$values})
+                ON DUPLICATE KEY UPDATE {$updates}
+                MYSQL
+        ,
+            $platform instanceof SqlitePlatform => <<<SQLITE
+                INSERT INTO {$this->table} ({$columns})
+                VALUES ({$values})
+                ON CONFLICT({$identifiers}) DO UPDATE SET {$updates}
+                SQLITE
+        ,
+            default => throw new RuntimeException(
                 sprintf('The database platform %s is not supported!', $platform::class),
                 1_603_199_935
             )


### PR DESCRIPTION
Doctrine uses `MySqlPlatform` as common parent class for all mysql-ish platforms up until DBAL version 3.2. Startig with DBAL version 3.3, the common class is `AbstractMySQLPlatform`.

This is especially important for all DBAL versions matching semver "^2.13".

Existing:
@see https://github.com/doctrine/dbal/blob/3.2.2/src/Platforms/MySQLPlatform.php @see https://github.com/doctrine/dbal/blob/3.3.0/src/Platforms/AbstractMySQLPlatform.php

Missing:
@see https://github.com/doctrine/dbal/blob/3.2.2/src/Platforms/AbstractMySQLPlatform.php @see https://github.com/doctrine/dbal/blob/3.3.0/src/Platforms/MySQLPlatform.php