### PR TITLE
fix: call lastInsertId only once with multiple customFieldProcessors

### DIFF
--- a/src/Upsert.php
+++ b/src/Upsert.php
@@ -146,8 +146,11 @@ final class Upsert
             array_combine(array_keys($allFields), array_column($allFields, 'type'))
         );
 
-        foreach ($this->customFieldProcessors as $processor) {
-            $processor->postUpsert($this->table, $allFields, (int) $this->connection->lastInsertId());
+        if ($this->customFieldProcessors !== []) {
+            $id = (int)$this->connection->lastInsertId();
+            foreach ($this->customFieldProcessors as $processor) {
+                $processor->postUpsert($this->table, $allFields, $id);
+            }
         }
 
         return $result->rowCount();


### PR DESCRIPTION
Previously, when multiple customFieldProcessors were registered, lastInsertId was invoked multiple times, causing an exception since the ID had already been retrieved. This change ensures lastInsertId is only called once.